### PR TITLE
Fix Spoils Phase UI not updating after quest completion

### DIFF
--- a/src/features/expedition/SpoilsPhase.tsx
+++ b/src/features/expedition/SpoilsPhase.tsx
@@ -28,9 +28,6 @@ export default function SpoilsPhase({ campaignId }: SpoilsPhaseProps) {
   const spoilsProgress = expedition?.spoilsProgress;
   const knightChoices = expedition?.knightChoices || [];
 
-  // Debug logging
-  console.log('SpoilsPhase render - knightChoices:', knightChoices);
-
   // Helper function to get quest level for a knight
   const getQuestLevel = (knightUID: string): string => {
     const knight = knightsById[knightUID];
@@ -317,7 +314,6 @@ export default function SpoilsPhase({ campaignId }: SpoilsPhaseProps) {
     }
 
     // Update the knight's sheet
-    console.log('Updating knight sheet for:', knightUID, 'with:', updatedChapterProgress);
     updateKnightSheet(knightUID, {
       chapters: {
         ...knight.sheet.chapters,
@@ -327,7 +323,6 @@ export default function SpoilsPhase({ campaignId }: SpoilsPhaseProps) {
   };
 
   const handleCompleteQuest = (knightUID: string, choice: { choice: string }) => {
-    console.log('handleCompleteQuest called with:', { knightUID, choice });
     const choiceType =
       choice.choice === 'quest'
         ? 'Quest'
@@ -345,11 +340,6 @@ export default function SpoilsPhase({ campaignId }: SpoilsPhaseProps) {
             details => {
               const finalDetails =
                 details && details.trim() ? details.trim() : 'Completed successfully';
-              console.log('Calling completeQuest with success:', {
-                campaignId,
-                knightUID,
-                details: finalDetails,
-              });
               completeQuest(campaignId, knightUID, 'success', finalDetails);
               updateKnightData(knightUID, choice, 'success');
             }
@@ -364,11 +354,6 @@ export default function SpoilsPhase({ campaignId }: SpoilsPhaseProps) {
             `Enter details about why the ${choice.choice} failed:`,
             details => {
               const finalDetails = details && details.trim() ? details.trim() : 'Failed';
-              console.log('Calling completeQuest with failure:', {
-                campaignId,
-                knightUID,
-                details: finalDetails,
-              });
               completeQuest(campaignId, knightUID, 'failure', finalDetails);
               updateKnightData(knightUID, choice, 'failure');
             }

--- a/src/store/campaigns.ts
+++ b/src/store/campaigns.ts
@@ -1,13 +1,13 @@
 import type {
-    Campaign,
-    CampaignsState,
-    ClashResult,
-    Clue,
-    Contract,
-    ExpeditionPhase,
-    KnightExpeditionChoice,
-    LootCard,
-    Objective,
+  Campaign,
+  CampaignsState,
+  ClashResult,
+  Clue,
+  Contract,
+  ExpeditionPhase,
+  KnightExpeditionChoice,
+  LootCard,
+  Objective,
 } from '@/models/campaign';
 import { create } from 'zustand';
 import { storage, STORAGE_KEYS } from './storage';
@@ -1492,24 +1492,13 @@ export const useCampaigns = create<CampaignsState & CampaignsActions>((set, get)
 
     completeQuest: (campaignId, knightUID, status, details, rewards) =>
       set(s => {
-        console.log('completeQuest called with:', {
-          campaignId,
-          knightUID,
-          status,
-          details,
-          rewards,
-        });
         const c = s.campaigns[campaignId];
-        console.log('Campaign data:', c);
-        console.log('Expedition data:', c?.expedition);
         if (!c?.expedition) {
-          console.log('No expedition found');
           return s;
         }
 
         // Initialize spoilsProgress if it doesn't exist
         if (!c.expedition.spoilsProgress) {
-          console.log('Initializing spoilsProgress');
           c.expedition.spoilsProgress = {
             lootDeck: [],
             goldEarned: 0,
@@ -1564,18 +1553,6 @@ export const useCampaigns = create<CampaignsState & CampaignsActions>((set, get)
             },
           },
         };
-        console.log(
-          'Updated expedition state:',
-          newState.campaigns[campaignId]?.expedition?.knightChoices
-        );
-        console.log(
-          'Updated knight choice for',
-          knightUID,
-          ':',
-          newState.campaigns[campaignId]?.expedition?.knightChoices?.find(
-            c => c.knightUID === knightUID
-          )
-        );
         saveToStorage(newState);
         return newState;
       }),

--- a/src/store/campaigns.ts
+++ b/src/store/campaigns.ts
@@ -1,13 +1,13 @@
 import type {
-  Campaign,
-  CampaignsState,
-  ClashResult,
-  Clue,
-  Contract,
-  ExpeditionPhase,
-  KnightExpeditionChoice,
-  LootCard,
-  Objective,
+    Campaign,
+    CampaignsState,
+    ClashResult,
+    Clue,
+    Contract,
+    ExpeditionPhase,
+    KnightExpeditionChoice,
+    LootCard,
+    Objective,
 } from '@/models/campaign';
 import { create } from 'zustand';
 import { storage, STORAGE_KEYS } from './storage';
@@ -1492,13 +1492,39 @@ export const useCampaigns = create<CampaignsState & CampaignsActions>((set, get)
 
     completeQuest: (campaignId, knightUID, status, details, rewards) =>
       set(s => {
+        console.log('completeQuest called with:', {
+          campaignId,
+          knightUID,
+          status,
+          details,
+          rewards,
+        });
         const c = s.campaigns[campaignId];
-        if (!c?.expedition?.spoilsProgress) return s;
+        console.log('Campaign data:', c);
+        console.log('Expedition data:', c?.expedition);
+        if (!c?.expedition) {
+          console.log('No expedition found');
+          return s;
+        }
+
+        // Initialize spoilsProgress if it doesn't exist
+        if (!c.expedition.spoilsProgress) {
+          console.log('Initializing spoilsProgress');
+          c.expedition.spoilsProgress = {
+            lootDeck: [],
+            goldEarned: 0,
+            gearAcquired: [],
+            questCompletions: [],
+          };
+        }
 
         const knightChoice = c.expedition.knightChoices.find(
           choice => choice.knightUID === knightUID
         );
         if (!knightChoice) return s;
+
+        // Note: Knight data updates will be handled by the UI components
+        // to avoid circular dependencies between stores
 
         const questCompletion = {
           knightUID,
@@ -1538,6 +1564,18 @@ export const useCampaigns = create<CampaignsState & CampaignsActions>((set, get)
             },
           },
         };
+        console.log(
+          'Updated expedition state:',
+          newState.campaigns[campaignId]?.expedition?.knightChoices
+        );
+        console.log(
+          'Updated knight choice for',
+          knightUID,
+          ':',
+          newState.campaigns[campaignId]?.expedition?.knightChoices?.find(
+            c => c.knightUID === knightUID
+          )
+        );
         saveToStorage(newState);
         return newState;
       }),


### PR DESCRIPTION
- Fixed completeQuest function failing due to missing spoilsProgress object
- Added automatic initialization of spoilsProgress when it doesn't exist
- Made Alert.prompt details optional with default values for better UX
- Added debugging logs to track expedition data updates
- Resolved circular dependency between campaigns and knights stores
- Moved knight sheet updates to UI layer to avoid store coupling

The Spoils Phase UI now properly reflects quest/investigation completion status with visual feedback (colored buttons, status text updates).