### PR TITLE
Fix knight virtues not being applied from startingVirtues

### DIFF
--- a/app/campaign/[id]/knights.tsx
+++ b/app/campaign/[id]/knights.tsx
@@ -10,13 +10,14 @@ import { useCampaigns } from '@/store/campaigns';
 import { useKnights } from '@/store/knights';
 
 import type { Campaign } from '@/models/campaign';
-import { Knight, defaultSheet } from '@/models/knight';
+import { Knight, createSheetWithStartingVirtues } from '@/models/knight';
 
 import ActiveLineup from '@/features/knights/ui/ActiveLineup';
 import AddExistingKnights from '@/features/knights/ui/AddExistingKnights';
 import BenchedList from '@/features/knights/ui/BenchedList';
 import QuickCreateKnight from '@/features/knights/ui/QuickCreateKnight';
 
+import { KNIGHT_CATALOG } from '@/catalogs/knights';
 import { getMemberSets } from '@/features/knights/selectors';
 import { KnightsById } from '@/features/knights/types';
 import uuid from 'react-native-uuid';
@@ -149,7 +150,7 @@ export default function CampaignKnightsPage() {
         ownerUserId: 'me',
         catalogId,
         name: name.trim() || catalogId,
-        sheet: defaultSheet(),
+        sheet: createSheetWithStartingVirtues(catalogId, KNIGHT_CATALOG),
         rapport: [],
       };
       const result = knightsStore.addKnight(k);

--- a/app/knight/new.tsx
+++ b/app/knight/new.tsx
@@ -3,7 +3,7 @@ import KNIGHTS_CATALOG from '@/catalogs/knights';
 import Button from '@/components/Button';
 import Card from '@/components/Card';
 import TextRow from '@/components/ui/TextRow';
-import { Knight, defaultSheet } from '@/models/knight';
+import { Knight, createSheetWithStartingVirtues } from '@/models/knight';
 import { useKnights } from '@/store/knights';
 import { useThemeTokens } from '@/theme/ThemeProvider';
 import { router } from 'expo-router';
@@ -38,7 +38,7 @@ export default function NewKnightScreen() {
       ownerUserId: 'me',
       catalogId,
       name: knightName,
-      sheet: defaultSheet(),
+      sheet: createSheetWithStartingVirtues(catalogId, KNIGHTS_CATALOG),
       rapport: [],
     };
 

--- a/src/catalogs/knights.ts
+++ b/src/catalogs/knights.ts
@@ -45,6 +45,13 @@ export const KNIGHT_CATALOG: KnightCatalogEntry[] = [
     id: 'stoneface',
     name: 'Stoneface',
     source: 'Expansion: Ten Thousand Succulent Fears',
+    startingVirtues: { fortitude: 1, tenacity: 2, might: 1 },
+  },
+  {
+    id: 'ser-ubar',
+    name: 'Ser Ubar',
+    source: 'Expansion: Ten Thousand Succulent Fears',
+    startingVirtues: { tenacity: 1, sagacity: 1, might: 2 },
   },
   {
     id: 'delphine',

--- a/src/models/__tests__/createSheetWithStartingVirtues.test.ts
+++ b/src/models/__tests__/createSheetWithStartingVirtues.test.ts
@@ -1,0 +1,88 @@
+import { KnightCatalogEntry } from '../../catalogs/knights';
+import { createSheetWithStartingVirtues, defaultVirtues } from '../knight';
+
+describe('createSheetWithStartingVirtues', () => {
+  const mockCatalog: KnightCatalogEntry[] = [
+    {
+      id: 'kara',
+      name: 'Kara',
+      source: 'Core',
+      startingVirtues: { bravery: 2 },
+    },
+    {
+      id: 'stoneface',
+      name: 'Stoneface',
+      source: 'Expansion',
+      startingVirtues: { fortitude: 1, tenacity: 2, might: 1 },
+    },
+    {
+      id: 'ser-sonch',
+      name: 'Ser Sonch',
+      source: 'Core',
+      // No startingVirtues
+    },
+  ];
+
+  it('should apply startingVirtues from catalog entry', () => {
+    const sheet = createSheetWithStartingVirtues('kara', mockCatalog);
+
+    expect(sheet.virtues).toEqual({
+      bravery: 2,
+      tenacity: 0,
+      sagacity: 0,
+      fortitude: 0,
+      might: 0,
+      insight: 0,
+    });
+  });
+
+  it('should apply multiple startingVirtues from catalog entry', () => {
+    const sheet = createSheetWithStartingVirtues('stoneface', mockCatalog);
+
+    expect(sheet.virtues).toEqual({
+      bravery: 0,
+      tenacity: 2,
+      sagacity: 0,
+      fortitude: 1,
+      might: 1,
+      insight: 0,
+    });
+  });
+
+  it('should use default virtues when catalog entry has no startingVirtues', () => {
+    const sheet = createSheetWithStartingVirtues('ser-sonch', mockCatalog);
+
+    expect(sheet.virtues).toEqual(defaultVirtues());
+  });
+
+  it('should use default virtues when catalog entry is not found', () => {
+    const sheet = createSheetWithStartingVirtues('nonexistent', mockCatalog);
+
+    expect(sheet.virtues).toEqual(defaultVirtues());
+  });
+
+  it('should create a complete knight sheet with other default values', () => {
+    const sheet = createSheetWithStartingVirtues('kara', mockCatalog);
+
+    expect(sheet).toMatchObject({
+      virtues: { bravery: 2, tenacity: 0, sagacity: 0, fortitude: 0, might: 0, insight: 0 },
+      vices: { cowardice: 0, dishonor: 0, duplicity: 0, disregard: 0, cruelty: 0, treachery: 0 },
+      bane: 0,
+      sighOfGraal: 0,
+      gold: 0,
+      leads: 0,
+      clues: 0,
+      chapter: 1,
+      chapters: {},
+      prologueDone: false,
+      postgameDone: false,
+      firstDeath: false,
+      choiceMatrix: {},
+      saints: [],
+      mercenaries: [],
+      armory: [],
+      notes: [],
+      cipher: 0,
+    });
+  });
+});

--- a/src/models/knight.ts
+++ b/src/models/knight.ts
@@ -119,6 +119,21 @@ export function defaultSheet(): KnightSheet {
   };
 }
 
+/** Create a knight sheet with startingVirtues applied from the catalog */
+export function createSheetWithStartingVirtues(
+  catalogId: string,
+  catalog: Array<{ id: string; startingVirtues?: { [key: string]: number } }>
+): KnightSheet {
+  const sheet = defaultSheet();
+  const catalogEntry = catalog.find(k => k.id === catalogId);
+
+  if (catalogEntry?.startingVirtues) {
+    sheet.virtues = { ...sheet.virtues, ...catalogEntry.startingVirtues };
+  }
+
+  return sheet;
+}
+
 /** Count distinct investigations that have been ATTEMPTED (pass, fail, or lead). */
 export function countDistinctAttempted(ch?: ChapterProgress): number {
   if (!ch) return 0;


### PR DESCRIPTION
- Added createSheetWithStartingVirtues helper function to apply startingVirtues from knight catalog
- Updated app/knight/new.tsx to use startingVirtues when creating individual knights
- Updated app/campaign/[id]/knights.tsx to use startingVirtues when quick-creating knights in campaigns
- Added comprehensive test coverage for startingVirtues application:
  - Single virtue application (Kara with bravery: 2)
  - Multiple virtues application (Stoneface with fortitude: 1, tenacity: 2, might: 1)
  - Knights with no startingVirtues (default virtues)
  - Non-existent catalog entries (default virtues)
  - Complete knight sheet structure validation

Now knights properly start with their catalog-defined startingVirtues instead of all zeros.