### PR TITLE
Add monster levels to selection modal

### DIFF
--- a/app/campaign/[id]/__tests__/gear.test.tsx
+++ b/app/campaign/[id]/__tests__/gear.test.tsx
@@ -194,6 +194,7 @@ describe('CampaignGear', () => {
         endExpedition: jest.fn(),
         setExpansionEnabled: jest.fn(),
         initializeDistrictWheel: jest.fn(),
+        updateDistrictWheelForCurrentStage: jest.fn(),
         rotateDistrictWheel: jest.fn(),
         replaceDistrictMonster: jest.fn(),
       };

--- a/src/features/expedition/DistrictWheel.tsx
+++ b/src/features/expedition/DistrictWheel.tsx
@@ -109,8 +109,8 @@ export default function DistrictWheel({
               </Text>
               {assignment && (
                 <Text style={{ fontSize: 14, color: tokens.textMuted, marginTop: 4 }}>
-                  {selectMonsterName(assignment.monsterId)(monstersState)} (Level {assignment.level}
-                  )
+                  {selectMonsterName(assignment.monsterId)(monstersState)} (Level{' '}
+                  {bestiary.stages[stageIndex]?.[assignment.monsterId] || 'Unknown'})
                 </Text>
               )}
             </View>
@@ -144,6 +144,11 @@ export default function DistrictWheel({
                 ?.monsterId
             : undefined
         }
+        partyLeaderChoice={partyLeaderChoice}
+        currentChapter={currentChapter}
+        allKnightChoices={allKnightChoices}
+        partyLeaderCompletedInvestigations={partyLeaderCompletedInvestigations}
+        campaignExpansions={campaignExpansions}
       />
     </Card>
   );

--- a/src/features/kingdoms/utils.ts
+++ b/src/features/kingdoms/utils.ts
@@ -58,20 +58,22 @@ export function calculateExpeditionMonsterStage(
     return 0; // Default to first stage for free-roam
   }
 
-  let stageIndex = 0;
+  // Calculate the base stage index for the current chapter
+  // Chapter 1 = 0-3, Chapter 2 = 4-7, Chapter 3 = 8-11, etc.
+  const chapterBaseIndex = (partyLeaderChapter - 1) * 4;
+
+  // Calculate the stage within the current chapter
+  let stageWithinChapter = 0;
 
   if (partyLeaderChoice.choice === 'quest') {
-    // For quest, use the number of completed investigations
-    stageIndex = partyLeaderCompletedInvestigations;
+    // For quest, use the number of completed investigations within this chapter
+    stageWithinChapter = partyLeaderCompletedInvestigations;
   } else if (partyLeaderChoice.choice === 'investigation') {
-    // For investigation, use completed investigations + 1
-    stageIndex = partyLeaderCompletedInvestigations + 1;
+    // For investigation, use completed investigations + 1 within this chapter
+    stageWithinChapter = partyLeaderCompletedInvestigations + 1;
   }
 
-  // Add chapter offset: each chapter has 4 stages (0-3, 4-7, 8-11, etc.)
-  const chapterOffset = (partyLeaderChapter - 1) * 4;
-
-  return chapterOffset + stageIndex;
+  return chapterBaseIndex + stageWithinChapter;
 }
 
 /**

--- a/src/models/__tests__/district.test.ts
+++ b/src/models/__tests__/district.test.ts
@@ -89,11 +89,8 @@ describe('District Wheel System', () => {
 
       // Check that monster IDs and stages are preserved
       expect(rotatedWheel.assignments[0].monsterId).toBe('monster-1');
-      expect(rotatedWheel.assignments[0].level).toBe(5);
       expect(rotatedWheel.assignments[1].monsterId).toBe('monster-2');
-      expect(rotatedWheel.assignments[1].level).toBe(10);
       expect(rotatedWheel.assignments[2].monsterId).toBe('monster-3');
-      expect(rotatedWheel.assignments[2].level).toBe(15);
     });
 
     it('should increment rotation counter on each rotation', () => {

--- a/src/models/district.ts
+++ b/src/models/district.ts
@@ -15,7 +15,6 @@ export type District = {
 export type DistrictAssignment = {
   districtId: string;
   monsterId: string;
-  level: number; // Monster level based on party leader's current chapter/progress
 };
 
 export type DistrictWheel = {

--- a/src/store/__tests__/district-wheel.test.ts
+++ b/src/store/__tests__/district-wheel.test.ts
@@ -38,9 +38,9 @@ describe('District Wheel Integration', () => {
       const districtNames = ['Drowned District', 'Marsh District', 'Mud District'];
 
       const assignments = [
-        { districtId: 'sunken-kingdom-drowned-district', monsterId: 'monster-1', level: 1 },
-        { districtId: 'sunken-kingdom-marsh-district', monsterId: 'monster-2', level: 1 },
-        { districtId: 'sunken-kingdom-mud-district', monsterId: 'monster-3', level: 1 },
+        { districtId: 'sunken-kingdom-drowned-district', monsterId: 'monster-1' },
+        { districtId: 'sunken-kingdom-marsh-district', monsterId: 'monster-2' },
+        { districtId: 'sunken-kingdom-mud-district', monsterId: 'monster-3' },
       ];
 
       const wheel = createDistrictWheel(kingdomId, districtNames, assignments);
@@ -59,7 +59,6 @@ describe('District Wheel Integration', () => {
       // Check assignments
       expect(wheel.assignments[0].districtId).toBe('sunken-kingdom-drowned-district');
       expect(wheel.assignments[0].monsterId).toBe('monster-1');
-      expect(wheel.assignments[0].level).toBe(1);
     });
 
     it('should rotate district wheel correctly', () => {
@@ -67,9 +66,9 @@ describe('District Wheel Integration', () => {
       const districtNames = ['Drowned District', 'Marsh District', 'Mud District'];
 
       const assignments = [
-        { districtId: 'sunken-kingdom-drowned-district', monsterId: 'monster-1', level: 1 },
-        { districtId: 'sunken-kingdom-marsh-district', monsterId: 'monster-2', level: 1 },
-        { districtId: 'sunken-kingdom-mud-district', monsterId: 'monster-3', level: 1 },
+        { districtId: 'sunken-kingdom-drowned-district', monsterId: 'monster-1' },
+        { districtId: 'sunken-kingdom-marsh-district', monsterId: 'monster-2' },
+        { districtId: 'sunken-kingdom-mud-district', monsterId: 'monster-3' },
       ];
 
       const wheel = createDistrictWheel(kingdomId, districtNames, assignments);
@@ -95,9 +94,9 @@ describe('District Wheel Integration', () => {
       const districtNames = ['Drowned District', 'Marsh District', 'Mud District'];
 
       const assignments = [
-        { districtId: 'sunken-kingdom-drowned-district', monsterId: 'monster-1', level: 1 },
-        { districtId: 'sunken-kingdom-marsh-district', monsterId: 'monster-2', level: 1 },
-        { districtId: 'sunken-kingdom-mud-district', monsterId: 'monster-3', level: 1 },
+        { districtId: 'sunken-kingdom-drowned-district', monsterId: 'monster-1' },
+        { districtId: 'sunken-kingdom-marsh-district', monsterId: 'monster-2' },
+        { districtId: 'sunken-kingdom-mud-district', monsterId: 'monster-3' },
       ];
 
       let wheel = createDistrictWheel(kingdomId, districtNames, assignments);
@@ -108,7 +107,7 @@ describe('District Wheel Integration', () => {
 
       expect(wheel.currentRotation).toBe(2);
 
-      // After 2 rotations, monsters should be back to original positions
+      // After 2 rotationsmonsters should be back to original positions
       expect(wheel.assignments[0].monsterId).toBe('monster-1');
       expect(wheel.assignments[1].monsterId).toBe('monster-2');
       expect(wheel.assignments[2].monsterId).toBe('monster-3');
@@ -119,14 +118,13 @@ describe('District Wheel Integration', () => {
       const districtNames = ['Noble', 'Craftsman', 'Port', 'Merchant'];
 
       const assignments = [
-        { districtId: 'principality-of-stone-noble', monsterId: 'monster-1', level: 2 },
+        { districtId: 'principality-of-stone-noble', monsterId: 'monster-1' },
         {
           districtId: 'principality-of-stone-craftsman',
           monsterId: 'monster-2',
-          level: 2,
         },
-        { districtId: 'principality-of-stone-port', monsterId: 'monster-3', level: 2 },
-        { districtId: 'principality-of-stone-merchant', monsterId: 'monster-4', level: 2 },
+        { districtId: 'principality-of-stone-port', monsterId: 'monster-3' },
+        { districtId: 'principality-of-stone-merchant', monsterId: 'monster-4' },
       ];
 
       const wheel = createDistrictWheel(kingdomId, districtNames, assignments);


### PR DESCRIPTION
- Add monster level display to MonsterSelectionModal component
- Calculate levels using same logic as district wheel
- Pass expedition data (party leader choice, chapter, investigations, expansions) to modal
- Display format: 'Monster Name (Level X)' for consistency
- Fix TypeScript types for proper type safety
- All tests passing