### PR TITLE
fix: ensure party leader selection immediately updates campaign state

### DIFF
--- a/src/features/expedition/VisionPhase.tsx
+++ b/src/features/expedition/VisionPhase.tsx
@@ -160,6 +160,9 @@ export default function VisionPhase({ campaignId }: VisionPhaseProps) {
   const handlePartyLeaderChange = (newLeaderUID: string) => {
     setSelectedPartyLeader(newLeaderUID);
 
+    // Immediately update the campaign's party leader so other views can access it
+    setPartyLeader(campaignId, newLeaderUID);
+
     // Clear quest choices from all knights except the new leader
     activeKnights.forEach(member => {
       if (member.knightUID !== newLeaderUID) {
@@ -189,7 +192,7 @@ export default function VisionPhase({ campaignId }: VisionPhaseProps) {
       return;
     }
 
-    // Set the party leader first
+    // Ensure party leader is set (this will be a no-op if already set)
     setPartyLeader(campaignId, selectedPartyLeader);
 
     // If expedition doesn't exist yet, start it

--- a/src/features/expedition/__tests__/VisionPhase.test.tsx
+++ b/src/features/expedition/__tests__/VisionPhase.test.tsx
@@ -316,6 +316,7 @@ describe('VisionPhase', () => {
 
       fireEvent.press(screen.getByText('Start Expedition'));
 
+      // setPartyLeader is now called when party leader is selected, not when expedition starts
       expect(mockStoreActions.setPartyLeader).toHaveBeenCalledWith('test-campaign-1', 'knight-1');
       expect(mockStoreActions.startExpedition).toHaveBeenCalledWith('test-campaign-1');
     });


### PR DESCRIPTION
- Call setPartyLeader immediately when party leader is selected in Vision Phase
- This ensures kingdom view and delve view can access the party leader
- Keep existing behavior for Start Expedition button as fallback
- Fixes issue where monster stages weren't populated until visiting other pages